### PR TITLE
Fix: table_translator.cc Index Out of bound

### DIFF
--- a/src/rime/gear/table_translator.cc
+++ b/src/rime/gear/table_translator.cc
@@ -499,10 +499,11 @@ void SentenceTranslation::PrepareSentence() {
   const string& delimiters(translator_->delimiters());
   // split syllables
   size_t pos = 0;
+  size_t blank = 0;
   for (int len : sentence_->word_lengths()) {
     if (pos > 0 && delimiters.find(input_[pos - 1]) == string::npos) {
-      preedit.insert(pos, 1, ' ');
-      ++pos;
+      preedit.insert(pos + blank, 1, ' ');
+      ++blank;
     }
     pos += len;
   }


### PR DESCRIPTION
there's a index out of bound on table_translator.cc:506
the error occurred when I try to input over about 20 characters.
Then I found when trying to add blank to preedit then increase pos, might leads input[pos - 1] out of bound.
I thought the pos should not be increased, instead using other varibles.